### PR TITLE
113 upload artifacts failing in ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,14 +96,15 @@ jobs:
       - name: Run Nox
         run: |
           nox --python=${{ matrix.python }}
-          ls
 
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'
         uses: "actions/upload-artifact@v4"
         with:
           name: coverage-data-${{matrix.python}}-${{matrix.os}}
-          path: hyperstruct/*/.coverage*
+          include-hidden-files: true
+          path: .coverage.*
+          if-no-files-found: error
 
       - name: Upload documentation
         if: matrix.session == 'docs-build'


### PR DESCRIPTION
This action ignores files with a `.` prefix by default. See documentation [here](https://github.com/actions/upload-artifact?tab=readme-ov-file#uploading-hidden-files)