### PR TITLE
Labeler work

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,14 +11,14 @@ jobs:
     permissions:
       actions: read
       contents: read
-      issues: write # <--- permission granted explicitely
+      issues: write # <--- permission granted explicitly
       security-events: write
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
 
       - name: Run Labeler
-        uses: crazy-max/ghaction-github-labeler@v5.1.0
+        uses: crazy-max/ghaction-github-labeler@v5.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           skip-delete: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Poetry
         run: |
           pip install --constraint=.github/workflows/constraints.txt poetry
-          pipx inject poetry poetry-plugin-export
+          pip install poetry-plugin-export
           poetry --version
 
       - name: Check if there is a parent commit


### PR DESCRIPTION
Fixing the labeler by downgrading to the last functional version. Getting the `e.replace` error. This appears to be a know bug in version 5.1.0.

Also correcting the Releases workflow to just use pip instead of pipx, as everything else is just in the single base environment.