### PR TITLE
Major frames refinement

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ predicated empirical formulas.
 These should probably become their own Issues, but they will at least become their own PR's. It's easier to list them all here for now.
 
 - [x] ForcedCrippling needs it's own class, so MinorFrames, Longerons, and Covers can utilize the same methods without repeating code.
-- [ ] MajorFrames need their own class for analysis methods.
+- [x] MajorFrames need their own class for analysis methods.
 - [ ] Fuselage class needs a cut method to generate geometry for analysis by averaging the geometry between defined sections.
 - [ ] How does the Fuselage class define where all the different load points (and therefor MajorFrames) are?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hyperstruct"
-version = "0.0.8"
+version = "0.0.9"
 description = "Hyperstruct"
 authors = ["Benjamin Crews <aceF22@gmail.com>"]
 license = "MIT"

--- a/src/hyperstruct/fuselage.py
+++ b/src/hyperstruct/fuselage.py
@@ -1281,9 +1281,6 @@ class Bulkhead(Component):
             t_bar: minimum equivalent stiffness
             d: stiffener spacing for minimum thickness
             H: stiffener width for minimum thickness
-
-        Raises:
-            ValueError: Converged thickness does not result in spacing within bounds.
         """
         x = np.linspace(d_1, d_2, num=5)
         y = []

--- a/tests/test_fuselage.py
+++ b/tests/test_fuselage.py
@@ -3,7 +3,6 @@
 import pytest
 
 from hyperstruct import Material
-from hyperstruct.fuselage import Bulkhead
 from hyperstruct.fuselage import Cover
 from hyperstruct.fuselage import ForcedCrippling
 
@@ -33,25 +32,6 @@ def unmilled_cover(aluminum: Material) -> Cover:
     """Build a Cover component."""
     component = Cover(
         material=aluminum, milled=False, L=30, D=20, R=1, RC=25, V=420.0, I=69.0, Q=69.0
-    )
-    return component
-
-
-@pytest.fixture
-def bulkhead(aluminum: Material) -> Bulkhead:
-    """Build a Bulkhead component."""
-    component = Bulkhead(
-        material=aluminum,
-        p_1=30.0,
-        p_2=6.0,
-        L=34.0,
-        K_r=0.53,
-        duf=1.5,
-        t_w=0.027,
-        t_l=0.080,
-        d=2.0,
-        t_s=0.090,
-        H=1.5,
     )
     return component
 
@@ -99,15 +79,6 @@ def test_unmilled_acoustic(unmilled_cover: Cover) -> None:
     t_l, t_c = unmilled_cover.acoustic_fatigue()
     assert isinstance(t_l, float)
     assert isinstance(t_c, float)
-
-
-def test_bulkhead_stiffener_spacing(bulkhead: Bulkhead) -> None:
-    """Test a pressure bulkhead."""
-    print(bulkhead.allowable_tensile_stress(0.53))
-    print(bulkhead.web_thickness(2.0))
-    t_s, d, H = bulkhead.stiffener_spacing()
-    assert t_s >= 0.025
-    assert t_s < 0.500
 
 
 def test_diagonal_tension(diag_ten: ForcedCrippling) -> None:

--- a/tests/test_hyperstruct.py
+++ b/tests/test_hyperstruct.py
@@ -203,40 +203,6 @@ if __name__ == "__main__":  # pragma: no cover
     # coords = [(y, z)]
 
     num = 25
-    zzf, inertias, cuts = frm.geometry_cuts(num, debug=False)
-    geom_df = pd.DataFrame(
-        cuts,
-        columns=[
-            "y_bj",
-            "z_bj",
-            "y_pbj",
-            "z_pbj",
-            "dlsp_j",
-            "y_i",
-            "z_i",
-            "y_p",
-            "z_p",
-            "theta_k",
-        ],
-    )
-    geom_df["theta_kdeg"] = np.degrees(geom_df.theta_k)
-    print("Geometry Cut Table")
-    print(geom_df)
-    geom_df.to_csv("geom.csv")
-
-    dls = (frm.geom.upper_panel + frm.geom.side_panel + frm.geom.lower_panel) / num
-    dlsp = np.mean(cuts[:, 4])
-    print(f" DLS = {dls:.1f}[in]")
-    print(f"DLSP = {dlsp:.1f}[in]")
-    print("")
-
-    print("Internal Loads Table:")
-    loads = pd.DataFrame(
-        frm.frame_loads(dls, zzf, inertias, cuts), columns=["shear", "axial", "bending"]
-    )
-    loads.to_csv("loads.csv")
-    print(loads)
-    print("")
 
     frm.synthesis(num)
     sizing = pd.DataFrame(frm.results, columns=["w_j", "tcap", "t_w_str", "t_w_res"])

--- a/tests/test_hyperstruct.py
+++ b/tests/test_hyperstruct.py
@@ -1,16 +1,10 @@
 """Test cases for the general module."""
 
-from copy import copy
-
-import matplotlib.pyplot as plt
 import numpy as np
-import pandas as pd
 import pytest
 import pytest_check as pycheck
 
-from hyperstruct import Material
 from hyperstruct import Station
-from hyperstruct.fuselage import MajorFrame
 
 
 @pytest.fixture
@@ -141,87 +135,3 @@ def test_rounded(rounded: Station) -> None:
 
     pycheck.almost_equal(x, 30, abs=0.1)
     pycheck.almost_equal(y, 60, abs=0.1)
-
-
-if __name__ == "__main__":  # pragma: no cover
-    # This snippet just verifies the show method and get_coords.
-    material = Material(
-        rho=0.1,
-        E=10.5e6,
-        E_c=10.6e6,
-        nu=0.33,
-        F_tu=64e3,
-        F_ty=42.1e3,
-        F_cy=48.3e3,
-        F_su=41.0e3,
-        F_bru=10.04e3,
-        F_bry=89.0e3,
-        F_en=20.0e3,
-        db_r=116,
-    )
-
-    obj = Station(
-        orientation="FS",
-        name="Rounded Rectangle",
-        number=400.0,
-        width=60.0,
-        depth=50.0,
-        vertical_centroid=30.0,
-        radius=24,
-    )
-    # angles = np.linspace(0, np.pi, num=10)
-    # coords = []
-    # for theta in angles:
-    #     x, y = obj.get_coords(theta)
-    #     coords.append((x, y))
-
-    frm = MajorFrame(
-        material=material,
-        fs_loc=400.0,
-        loads=np.array(
-            [
-                [15.0, 56.5, 200.0, 10.0, 0.0],
-                [31.5, 30.0, 0.0, 0.0, 10.0],
-                [-15.0, 56.5, 200.0, -10.0, 0.0],
-                [-31.5, 30.0, 0.0, 0.0, -10.0],
-            ]
-        ),
-        geom=obj,
-        fd=6.0,
-    )
-    print(f"Upper Panel = {frm.geom.upper_panel:.3f}")
-    print(f" Side Panel = {frm.geom.side_panel:.3f}")
-    print(f"Lower Panel = {frm.geom.lower_panel:.3f}")
-
-    # Check coords
-    # y, z = frm.geom.get_coords(np.radians(130), debug=True)
-    # print(f"In quadrant 4: y={y:.1f}, z={z:.1f}\n")
-    # coords = [(y, z)]
-
-    # y, z = frm.geom.get_coords(np.radians(225), debug=True)
-    # print(f"In quadrant 3: y={y:.1f}, z={z:.1f}")
-    # coords = [(y, z)]
-
-    num = 25
-
-    frm.synthesis(num)
-    sizing = pd.DataFrame(frm.results, columns=["w_j", "tcap", "t_w_str", "t_w_res"])
-    print("Sizing Results Table")
-    print(sizing)
-    print(f"Frame weight = {frm.weight:.1f} [lbs]")
-
-    _ = frm.show(show_coords=True, save=False)
-
-    # Sweep over number of cuts to observe the prediction sensitivity
-    nums = np.linspace(15, 90, dtype=int, num=25)
-    weights = []
-    for n in nums:
-        frm.synthesis(n)
-        weights.append(copy(frm.weight))
-
-    ser = pd.Series(weights, index=nums, name="Frame Weight Sweep")
-    ser.index.name = "Cuts"
-    print(ser)
-
-    ser.plot(kind="bar", ylim=(0, 500), ylabel="weight")
-    plt.show()

--- a/tests/test_major_frames.py
+++ b/tests/test_major_frames.py
@@ -1,0 +1,148 @@
+"""Test cases for the MajorFrame classes."""
+
+import numpy as np
+import pandas as pd
+import pytest
+import pytest_check as pycheck
+
+from hyperstruct import Material
+from hyperstruct import Station
+from hyperstruct.fuselage import MajorFrame
+
+
+@pytest.fixture
+def aluminum() -> Material:
+    """Basic aluminum."""
+    material = Material(
+        rho=0.101,
+        E=10.5e6,
+        E_c=10.6e6,
+        nu=0.33,
+        F_tu=79.0e3,
+        F_ty=42.1e3,
+        F_cy=48.3e3,
+        F_su=47.0e3,
+        F_bru=142.0e3,
+        F_bry=104.0e3,
+        F_en=20.0e3,
+        db_r=116,
+    )
+    return material
+
+
+@pytest.fixture
+def rounded() -> Station:
+    """Build a Station class that is rectangular."""
+    obj = Station(
+        orientation="FS",
+        name="Rounded Rectangle",
+        number=400.0,
+        width=60.0,
+        depth=60.0,
+        vertical_centroid=60.0,
+        radius=15.0,
+    )
+    return obj
+
+
+def test_frame(aluminum: Material, rounded: Station) -> None:
+    """Test a major frame."""
+    frame = MajorFrame(
+        material=aluminum,
+        fs_loc=rounded.number,
+        loads=np.array(
+            [
+                # y, z, V, H, M
+                [15.0, 56.5, -20876.0, 0.0, 0.0],
+                [-15.0, 56.5, -20876.0, 0.0, 0.0],
+            ]
+        ),
+        geom=rounded,
+        fd=6.0,
+    )
+    # Verify we don't have the attribute before synthesis
+    pycheck.is_false(hasattr(frame, "weight"))
+    frame.synthesis()
+    # Check against expected weight after synthesis
+    pycheck.almost_equal(frame.weight, 60.8, rel=0.1)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    # This snippet just verifies the show method and get_coords.
+    material = Material(
+        rho=0.101,
+        E=10.5e6,
+        E_c=10.6e6,
+        nu=0.33,
+        F_tu=79.0e3,
+        F_ty=42.1e3,
+        F_cy=48.3e3,
+        F_su=47.0e3,
+        F_bru=142.0e3,
+        F_bry=104.0e3,
+        F_en=20.0e3,
+        db_r=116,
+    )
+
+    obj = Station(
+        orientation="FS",
+        name="Rounded Rectangle",
+        number=1728.0,
+        width=60.0,
+        depth=50.0,
+        vertical_centroid=30.0,
+        radius=24.61,
+    )
+
+    frm = MajorFrame(
+        material=material,
+        fs_loc=obj.number,
+        loads=np.array(
+            [
+                # y, z, V, H, M
+                [15.0, 56.5, -20876.0, 0.0, 0.0],
+                [-15.0, 56.5, -20876.0, 0.0, 0.0],
+            ]
+        ),
+        geom=obj,
+        fd=6.0,
+    )
+    print(f"Upper Panel = {frm.geom.upper_panel:.3f}")
+    print(f" Side Panel = {frm.geom.side_panel:.3f}")
+    print(f"Lower Panel = {frm.geom.lower_panel:.3f}")
+
+    # Check coords
+    # y, z = frm.geom.get_coords(np.radians(130), debug=True)
+    # print(f"In quadrant 4: y={y:.1f}, z={z:.1f}\n")
+    # coords = [(y, z)]
+
+    # y, z = frm.geom.get_coords(np.radians(225), debug=True)
+    # print(f"In quadrant 3: y={y:.1f}, z={z:.1f}")
+    # coords = [(y, z)]
+
+    num = 25
+
+    frm.synthesis(num)
+    print("Geometry Table")
+    print(frm.cuts)
+
+    sizing = pd.DataFrame(frm.results, columns=["w_j", "tcap", "t_w_str", "t_w_res"])
+    print("Sizing Results Table")
+    print(sizing)
+    print(f"Frame weight = {frm.weight:.1f} [lbs]")
+
+    _ = frm.show(show_coords=True, save=False)
+
+    # Sweep over number of cuts to observe the prediction sensitivity
+    # nums = np.linspace(15, 90, dtype=int, num=25)
+    # weights = []
+    # for n in nums:
+    #     frm.synthesis(n)
+    #     weights.append(copy(frm.weight))
+
+    # ser = pd.Series(weights, index=nums, name="Frame Weight Sweep")
+    # ser.index.name = "Cuts"
+    # print(ser)
+
+    # ser.plot(kind="bar", ylabel="weight")
+    # plt.show()

--- a/tests/test_major_frames.py
+++ b/tests/test_major_frames.py
@@ -1,4 +1,4 @@
-"""Test cases for the MajorFrame classes."""
+"""Test cases for the MajorFrame and Bulkhead classes."""
 
 import numpy as np
 import pandas as pd
@@ -7,6 +7,7 @@ import pytest_check as pycheck
 
 from hyperstruct import Material
 from hyperstruct import Station
+from hyperstruct.fuselage import Bulkhead
 from hyperstruct.fuselage import MajorFrame
 
 
@@ -67,6 +68,16 @@ def test_frame(aluminum: Material, rounded: Station) -> None:
     pycheck.almost_equal(frame.weight, 60.8, rel=0.1)
 
 
+def test_bulkhead(aluminum: Material) -> None:
+    """Check a basic Bulkhead for functionality."""
+    bulkhead = Bulkhead(material=aluminum, duf=2.0, K_r=0.6, p_1=3.2, p_2=7.1, L=30.0)
+    # Verify we don't have the attribute before synthesis
+    pycheck.is_false(hasattr(bulkhead, "weight"))
+    bulkhead.synthesis()
+    # Check against expected weight after synthesis
+    pycheck.almost_equal(bulkhead.weight, 6, rel=0.1)
+
+
 if __name__ == "__main__":  # pragma: no cover
     # This snippet just verifies the show method and get_coords.
     material = Material(
@@ -93,10 +104,19 @@ if __name__ == "__main__":  # pragma: no cover
         vertical_centroid=30.0,
         radius=24.61,
     )
+    cir = Station(
+        orientation="FS",
+        name="Circle",
+        number=1700.0,
+        width=50.0,
+        depth=50.0,
+        vertical_centroid=30.0,
+        radius=25.0,
+    )
 
     frm = MajorFrame(
         material=material,
-        fs_loc=obj.number,
+        fs_loc=cir.number,
         loads=np.array(
             [
                 # y, z, V, H, M
@@ -104,7 +124,7 @@ if __name__ == "__main__":  # pragma: no cover
                 [-15.0, 56.5, -20876.0, 0.0, 0.0],
             ]
         ),
-        geom=obj,
+        geom=cir,
         fd=6.0,
     )
     print(f"Upper Panel = {frm.geom.upper_panel:.3f}")


### PR DESCRIPTION
Merging in the last of Major Frames work, for now.

I've reached a point where I _could_ keep polishing this and checking, however I think it's more pertinent right now to focus on connecting more of the pieces to work with each other, rather than numerical accuracy of each piece. Some of the example tests I've run locally give me reasonable values, and the methods aren't numerically unstable.


For Major Frames, additional work could include:

- Check the results of loading against a circle, using the Ring Frame routines outlined in the NASA astronautics structures handbook. These routines are fully deterministic, so the elastic center method should match the loads very closely, for any number of cuts.
- Check the results of loading on a rounded rectangle against a FEM with 1d elements. I don't have a FEM code available for this, but a 1d frame using the exact same coordinates in the example should be an easy task to work this one out.
- Convergence studies. I really expected the weight value to converge as the number of cuts increased, and while it's stable, it's not converged. Is this a concern?

For Bulkheads:
- Kinda need a total overhaul on this class, because it needs to use the area methods outlined in the "internal geometry" section.
- I also don't have faith in the weight predictions here either.
- Finally, the class is clunky to define and use, with weird documentation deficiencies. Again, I could work on this but I need to spend my time elsewhere.