### PR TITLE
VMT and Loads Lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ These should probably become their own Issues, but they will at least become the
 - [x] MajorFrames need their own class for analysis methods.
 - [ ] Fuselage class needs a cut method to generate geometry for analysis by averaging the geometry between defined sections.
 - [ ] How does the Fuselage class define where all the different load points (and therefor MajorFrames) are?
-- [ ] Generate Shear-Moment-Torsion (VMT) diagrams for the fuselage.
-- [ ] Lookup loads at a synthesis cut, based on the net shell loads.
+- [x] Generate Shear-Moment-Torsion (VMT) diagrams for the fuselage.
+- [x] Lookup loads at a synthesis cut, based on the net shell loads.
 - [ ] Loadcase filtering based on the "Critical Shell Design Loads" criteria?
 - [ ] Where are all the interface loads calculated? They should apply to their MajorFrames, but does Fuselage calculate them?
+- [ ] Create an examples directory with pre-made components
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ pretty = true
 show_column_numbers = true
 show_error_codes = true
 show_error_context = true
-disable_error_code = ["import-untyped", "assignment", "operator", "index", "misc"]
+disable_error_code = ["import-untyped", "assignment", "operator", "index", "misc", "call-overload"]
 
 [build-system]
 requires = ["poetry-core>=2.0.0"]

--- a/src/hyperstruct/fuselage.py
+++ b/src/hyperstruct/fuselage.py
@@ -12,13 +12,15 @@ from dataclasses import field
 # from typing import Dict
 from typing import Any
 from typing import Tuple
+from numpy.typing import ArrayLike
 
 import matplotlib.pyplot as plt
-import numpy as np
-import pandas as pd
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 from matplotlib.lines import Line2D
 from matplotlib.patches import FancyArrowPatch
-from numpy.typing import ArrayLike
+import numpy as np
+import pandas as pd
 from scipy.optimize import minimize_scalar
 
 from hyperstruct import Component
@@ -2221,3 +2223,41 @@ class Fuselage:
 
         # Return the final arrays of internal shears and moments
         return loads
+
+    def vmt_diagram(
+        self, w_fus: ArrayLike, w_fc: ArrayLike, p_air: ArrayLike, p_ext: ArrayLike
+    ) -> Tuple[Figure, Tuple[Axes, Axes]]:
+        """Builds the Shear-Bending-Torsion Diagram.
+
+        !!Torsion currently Not Implemented!!
+
+        This method calls the net_loads method to generate a matrix of
+        applied and internal loads. It then puts these into a matplotlib
+        figure for visual verification. This isn't a necessary part
+        of the analysis, but it's good for documentation and visual verification
+        by humans.
+
+        Note, the arguments here are the external loads, not the result of the net_loads
+        method, because this function passes those to the net_loads method directly.
+
+        Args:
+            w_fus (ArrayLike): Distributed fuselage structural weights
+            w_fc (ArrayLike): Distributed fuselage content weights (nonstructural)
+            p_air (ArrayLike): Distributed body airloads
+            p_ext (ArrayLike): External forces at the support frames
+
+        Returns:
+            Tuple: Matplotlib Figure and the Axes it contains
+        """
+        loads = self.net_loads(w_fus, w_fc, p_air, p_ext)
+
+        fig, (ax1, ax2) = plt.subplots(nrows=2, sharex=True, figsize=(11, 5))
+        _ = ax1.plot(loads[:, 0], loads[:, 3])
+        _ = ax2.plot(loads[:, 0], loads[:, 4])
+
+        # _ = ax1.set_xlabel("Fuselage Station, $FS$, [in]")
+        _ = ax1.set_ylabel("Vertical Shear, $V$, [lbs]", fontfamily="serif")
+        _ = ax2.set_ylabel("Vertical Bending, $M$, [in-lbs]", fontfamily="serif")
+        _ = fig.supxlabel("Fuselage Station, $FS$, [in]", fontfamily="serif")
+
+        return (fig, (ax1, ax2))

--- a/tests/test_fuselage.py
+++ b/tests/test_fuselage.py
@@ -4,6 +4,8 @@ from typing import Tuple
 
 import numpy as np
 import pytest
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 from numpy.typing import ArrayLike
 
 from hyperstruct import Material
@@ -184,6 +186,14 @@ def test_net_loads(fuselage: Fuselage, fuse_loads: Tuple[ArrayLike]) -> None:
     assert internal_loads is not None
 
 
+def test_vmt_diagram(fuselage: Fuselage, fuse_loads: Tuple[ArrayLike]) -> None:
+    """Tests the diagram method."""
+    w_fus, w_fc, p_air, p_ext = fuse_loads
+    fig, axs = fuselage.vmt_diagram(w_fus, w_fc, p_air, p_ext)
+    assert isinstance(fig, Figure)
+    assert isinstance(axs[0], Axes)
+
+
 if __name__ == "__main__":  # pragma: no cover
     # Plot the example fuse loads for visual check
     # Prototype the VMT diagram code
@@ -255,16 +265,8 @@ if __name__ == "__main__":  # pragma: no cover
 
     fuse = Fuselage(stations=stations, major_frames=frames)
     loads = fuse.net_loads(w_fus, w_fc, p_air, p_ext)
+    fig, (ax1, ax2) = fuse.vmt_diagram(w_fus, w_fc, p_air, p_ext)
 
     print(loads)
-
-    fig, (ax1, ax2) = plt.subplots(nrows=2, sharex=True, figsize=(11, 5))
-    _ = ax1.plot(loads[:, 0], loads[:, 3])
-    _ = ax2.plot(loads[:, 0], loads[:, 4])
-
-    # _ = ax1.set_xlabel("Fuselage Station, $FS$, [in]")
-    _ = ax1.set_ylabel("Vertical Shear, $V$, [lbs]", fontfamily="serif")
-    _ = ax2.set_ylabel("Vertical Bending, $M$, [in-lbs]", fontfamily="serif")
-    _ = fig.supxlabel("Fuselage Station, $FS$, [in]", fontfamily="serif")
 
     plt.show()

--- a/tests/test_fuselage.py
+++ b/tests/test_fuselage.py
@@ -267,6 +267,16 @@ if __name__ == "__main__":  # pragma: no cover
     loads = fuse.net_loads(w_fus, w_fc, p_air, p_ext)
     fig, (ax1, ax2) = fuse.vmt_diagram(w_fus, w_fc, p_air, p_ext)
 
+    print("   FS     , P     , M_ext   , V     ,  M_int")
     print(loads)
+
+    print("\n\n")
+    x, v, m = fuse.lookup_loads(x=100, loads=loads)
+    print(x)
+    print(v)
+    print(m)
+
+    _ = ax1.plot(x, v, marker="^", color="k")
+    _ = ax2.plot(x, m, marker="^", color="k")
 
     plt.show()


### PR DESCRIPTION
This PR added two new methods to Fuselage: `vmt_diagram` and `lookup_loads`.

VMT Diagram is really just for visual verifcation and reporting. It's a standardized format that will be expanded in the future. Crucially, since there is currently no evaluation of cumulative torque on the fuselage, the 'T' of the VMT is notably absent.

The Lookup Loads method allows the user to retrieve the internal shear and bending at any station, regardless of whether external loads are defined there or not. This utilizes linear interpolation between the defined points, and is deemed accurate enough for these purposes.

I also removed the call-overload check in mypy, because it was annoying me.